### PR TITLE
Upgrading gRPC to 1.0.1, setting the Java version to 1.6, and fixing deprecation warnings

### DIFF
--- a/samples/buffering-grpc/pom.xml
+++ b/samples/buffering-grpc/pom.xml
@@ -41,13 +41,14 @@
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
-      <artifactId>google-auth-library-credentials</artifactId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
       <version>0.4.0</version>
     </dependency>
+
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
-      <version>0.14.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/samples/buffering-grpc/src/main/java/com/google/cloud/trace/samples/grpc/buffering/SimpleBufferingGrpc.java
+++ b/samples/buffering-grpc/src/main/java/com/google/cloud/trace/samples/grpc/buffering/SimpleBufferingGrpc.java
@@ -45,11 +45,9 @@ public class SimpleBufferingGrpc {
 
     // Create the raw tracer.
     TraceSource traceSource = new TraceSource();
-    ExecutorService executor = Executors.newSingleThreadExecutor();
     TraceSink traceSink = new GrpcTraceSink("cloudtrace.googleapis.com",
         GoogleCredentials.fromStream(new FileInputStream(clientSecretsFile))
-            .createScoped(Arrays.asList("https://www.googleapis.com/auth/trace.append")),
-        executor);
+            .createScoped(Arrays.asList("https://www.googleapis.com/auth/trace.append")));
     FlushableTraceSink flushableSink = new SimpleBufferingTraceSink(traceSink);
     RawTracer rawTracer = new RawTracerV1(projectId, traceSource, traceSink);
 
@@ -71,7 +69,5 @@ public class SimpleBufferingGrpc {
     tracer.endSpan(context1);
 
     flushableSink.flush();
-
-    executor.shutdownNow();
   }
 }

--- a/samples/guice-scheduled-grpc/pom.xml
+++ b/samples/guice-scheduled-grpc/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
-      <version>0.14.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/samples/guice-servlet-grpc/pom.xml
+++ b/samples/guice-servlet-grpc/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
-      <version>0.14.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/samples/managed-grpc/pom.xml
+++ b/samples/managed-grpc/pom.xml
@@ -41,13 +41,13 @@
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
-      <artifactId>google-auth-library-credentials</artifactId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
       <version>0.4.0</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
-      <version>0.14.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/samples/managed-grpc/src/main/java/com/google/cloud/trace/samples/grpc/managed/ManagedGrpc.java
+++ b/samples/managed-grpc/src/main/java/com/google/cloud/trace/samples/grpc/managed/ManagedGrpc.java
@@ -44,10 +44,8 @@ public class ManagedGrpc {
 
     // Create the raw tracer.
     TraceSource traceSource = new TraceSource();
-    ExecutorService executor = Executors.newSingleThreadExecutor();
     TraceSink traceSink = new GrpcTraceSink("cloudtrace.googleapis.com",
-        GoogleCredentials.getApplicationDefault(),
-        executor);
+        GoogleCredentials.getApplicationDefault());
     RawTracer rawTracer = new RawTracerV1(projectId, traceSource, traceSink);
 
     // Create the tracer.
@@ -71,7 +69,5 @@ public class ManagedGrpc {
     managedTracer.endSpan();
 
     managedTracer.endSpan();
-
-    executor.shutdownNow();
   }
 }

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -25,4 +25,20 @@
     <module>guice-servlet-grpc</module>
     <module>managed-grpc</module>
   </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.5.1</version>
+          <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/sdk/grpc-sink/pom.xml
+++ b/sdk/grpc-sink/pom.xml
@@ -26,8 +26,8 @@
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-cloudtrace-v1</artifactId>
-      <version>0.0.2</version>
+      <artifactId>grpc-google-devtools-cloudtrace-v1</artifactId>
+      <version>0.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>
@@ -37,12 +37,12 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-auth</artifactId>
-      <version>0.14.0</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
-      <version>0.14.0</version>
+      <version>1.0.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/sdk/grpc-sink/src/main/java/com/google/cloud/trace/grpc/v1/GrpcTraceSink.java
+++ b/sdk/grpc-sink/src/main/java/com/google/cloud/trace/grpc/v1/GrpcTraceSink.java
@@ -20,11 +20,9 @@ import com.google.devtools.cloudtrace.v1.PatchTracesRequest;
 import com.google.devtools.cloudtrace.v1.Trace;
 import com.google.devtools.cloudtrace.v1.Traces;
 import com.google.devtools.cloudtrace.v1.TraceServiceGrpc;
-import io.grpc.auth.ClientAuthInterceptor;
-import io.grpc.Channel;
-import io.grpc.ClientInterceptors;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.auth.MoreCallCredentials;
 import java.util.concurrent.Executor;
 
 /**
@@ -45,13 +43,13 @@ public class GrpcTraceSink implements TraceSink {
    *
    * @param apiHost     a string containing the API host name.
    * @param credentials a credentials used to authenticate API calls.
-   * @param executor    an executor used for managing the credentials.
    */
-  public GrpcTraceSink(String apiHost, Credentials credentials, Executor executor) {
+  public GrpcTraceSink(String apiHost, Credentials credentials) {
+    MoreCallCredentials.from(credentials);
     this.managedChannel = ManagedChannelBuilder.forTarget(apiHost).build();
-    Channel channel = ClientInterceptors.intercept(this.managedChannel,
-        new ClientAuthInterceptor(credentials, executor));
-    this.traceService = TraceServiceGrpc.newBlockingStub(channel);
+
+    this.traceService = TraceServiceGrpc.newBlockingStub(managedChannel)
+        .withCallCredentials(MoreCallCredentials.from(credentials));
   }
 
   @Override

--- a/sdk/guice/annotation/src/main/java/com/google/cloud/trace/guice/annotation/ManagedTracerSpanInterceptor.java
+++ b/sdk/guice/annotation/src/main/java/com/google/cloud/trace/guice/annotation/ManagedTracerSpanInterceptor.java
@@ -63,7 +63,7 @@ public class ManagedTracerSpanInterceptor implements MethodInterceptor {
               invocation.getMethod().getDeclaringClass().getPackage().getName());
     }
     if (span.entry()) {
-      labelsBeforeCallBuilder.add("trace.cloud.google.com/agent", "coud-trace-java/0.1");
+      labelsBeforeCallBuilder.add("trace.cloud.google.com/agent", "cloud-trace-java/0.1");
     }
 
     String methodName;

--- a/sdk/guice/grpc-sink/src/main/java/com/google/cloud/trace/guice/grpc/v1/GrpcTraceSinkModule.java
+++ b/sdk/guice/grpc-sink/src/main/java/com/google/cloud/trace/guice/grpc/v1/GrpcTraceSinkModule.java
@@ -33,7 +33,6 @@ public class GrpcTraceSinkModule extends AbstractModule {
   @ApiTraceSink
   @Singleton
   TraceSink provideTraceSink(@ApiHost String apiHost, Credentials credentials) {
-    // The executor does not yet appear to be used by the gRPC client auth interceptor.
-    return new GrpcTraceSink(apiHost, credentials, Executors.newSingleThreadExecutor());
+    return new GrpcTraceSink(apiHost, credentials);
   }
 }

--- a/sdk/guice/v1/pom.xml
+++ b/sdk/guice/v1/pom.xml
@@ -32,8 +32,8 @@
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-cloudtrace-v1</artifactId>
-      <version>0.0.2</version>
+      <artifactId>grpc-google-devtools-cloudtrace-v1</artifactId>
+      <version>0.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -25,4 +25,22 @@
     <module>servlet</module>
     <module>v1</module>
   </modules>
+
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.5.1</version>
+          <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/sdk/v1/pom.xml
+++ b/sdk/v1/pom.xml
@@ -32,8 +32,8 @@
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-cloudtrace-v1</artifactId>
-      <version>0.0.2</version>
+      <artifactId>grpc-google-devtools-cloudtrace-v1</artifactId>
+      <version>0.1.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/source/TraceSource.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/source/TraceSource.java
@@ -106,7 +106,7 @@ public class TraceSource {
         .setSpanId(context.getSpanId().getSpanId());
 
     for (Label label : labels.getLabels()) {
-      spanBuilder.getMutableLabels().put(label.getKey(), label.getValue());
+      spanBuilder.putLabels(label.getKey(), label.getValue());
     }
 
     return traceBuilder.build();
@@ -153,7 +153,7 @@ public class TraceSource {
     }
     stackTraceValue.append("]}");
 
-    spanBuilder.getMutableLabels().put(
+    spanBuilder.putLabels(
         "trace.cloud.google.com/stacktrace", stackTraceValue.toString());
 
     return traceBuilder.build();

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/util/RoughTraceSizer.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/util/RoughTraceSizer.java
@@ -56,7 +56,7 @@ public class RoughTraceSizer implements Sizer<Trace> {
 
   private int labelsSize(TraceSpan span) {
     int size = 0;
-    for (Map.Entry<String, String> label : span.getLabels().entrySet()) {
+    for (Map.Entry<String, String> label : span.getLabelsMap().entrySet()) {
       size += label.getKey().length() + label.getValue().length();
     }
     return size;


### PR DESCRIPTION
- Upgrading gRPC to version 1.0.1
- Setting the Java version to 1.6
- Fixing deprecation warnings