### PR TITLE
Changing TraceSink interface to accept Traces instead of Trace

### DIFF
--- a/sdk/core/pom.xml
+++ b/sdk/core/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.1.0-beta.120</version>
+      <version>2.2.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sdk/grpc-sink/src/main/java/com/google/cloud/trace/grpc/v1/GrpcTraceSink.java
+++ b/sdk/grpc-sink/src/main/java/com/google/cloud/trace/grpc/v1/GrpcTraceSink.java
@@ -30,7 +30,7 @@ import io.grpc.auth.MoreCallCredentials;
  *
  * @see <a href="http://www.grpc.io">gRPC</a>
  * @see Credentials
- * @see Trace
+ * @see Traces
  * @see TraceSink
  */
 public class GrpcTraceSink implements TraceSink {
@@ -50,13 +50,15 @@ public class GrpcTraceSink implements TraceSink {
   }
 
   @Override
-  public void receive(Trace trace) {
-    Traces.Builder traceBuilder = Traces.newBuilder().addTraces(trace);
-
+  public void receive(Traces traces) {
+    if (traces.getTracesCount() == 0) {
+      return;
+    }
+    String projectId = traces.getTraces(0).getProjectId();
     PatchTracesRequest.Builder requestBuilder =
         PatchTracesRequest.newBuilder()
-            .setProjectId(trace.getProjectId())
-            .setTraces(traceBuilder.build());
+            .setProjectId(projectId)
+            .setTraces(traces);
 
     traceService.patchTraces(requestBuilder.build());
   }

--- a/sdk/http-sink/src/main/java/com/google/cloud/trace/http/v1/HttpTraceSink.java
+++ b/sdk/http-sink/src/main/java/com/google/cloud/trace/http/v1/HttpTraceSink.java
@@ -30,8 +30,12 @@ public class HttpTraceSink implements TraceSink {
   }
 
   @Override
-  public void receive(Trace trace) {
-    processTraces(Traces.newBuilder().addTraces(trace).build(), trace.getProjectId());
+  public void receive(Traces traces) {
+    if (traces.getTracesCount() == 0) {
+      return;
+    }
+    String projectId = traces.getTraces(0).getProjectId();
+    processTraces(traces, projectId);
   }
 
   private void processTraces(Traces traces, String projectId) {

--- a/sdk/v1/pom.xml
+++ b/sdk/v1/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.1.0-beta.120</version>
+      <version>2.2.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sdk/v1/pom.xml
+++ b/sdk/v1/pom.xml
@@ -37,5 +37,17 @@
       <artifactId>protobuf-java</artifactId>
       <version>3.1.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>0.29</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.1.0-beta.120</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/RawTracerV1.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/RawTracerV1.java
@@ -23,6 +23,7 @@ import com.google.cloud.trace.util.TraceContext;
 import com.google.cloud.trace.v1.sink.TraceSink;
 import com.google.cloud.trace.v1.source.TraceSource;
 import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.Traces;
 
 /**
  * A raw tracer that converts trace events to Stackdriver Trace API v1 trace messages and dispatches
@@ -68,7 +69,7 @@ public class RawTracerV1 implements RawTracer {
     if (context.getTraceOptions().getTraceEnabled()) {
       Trace trace = traceSource.generateStartSpan(
           projectId, context, parentContext, spanKind, name, timestamp);
-      traceSink.receive(trace);
+      traceSink.receive(Traces.newBuilder().addTraces(trace).build());
     }
   }
 
@@ -76,7 +77,7 @@ public class RawTracerV1 implements RawTracer {
   public void endSpan(TraceContext context, Timestamp timestamp) {
     if (context.getTraceOptions().getTraceEnabled()) {
       Trace trace = traceSource.generateEndSpan(projectId, context, timestamp);
-      traceSink.receive(trace);
+      traceSink.receive(Traces.newBuilder().addTraces(trace).build());
     }
   }
 
@@ -84,7 +85,7 @@ public class RawTracerV1 implements RawTracer {
   public void annotateSpan(TraceContext context, Labels labels) {
     if (context.getTraceOptions().getTraceEnabled()) {
       Trace trace = traceSource.generateAnnotateSpan(projectId, context, labels);
-      traceSink.receive(trace);
+      traceSink.receive(Traces.newBuilder().addTraces(trace).build());
     }
   }
 
@@ -92,7 +93,7 @@ public class RawTracerV1 implements RawTracer {
   public void setStackTrace(TraceContext context, StackTrace stackTrace) {
     if (context.getTraceOptions().getTraceEnabled()) {
       Trace trace = traceSource.generateSetStackTrace(projectId, context, stackTrace);
-      traceSink.receive(trace);
+      traceSink.receive(Traces.newBuilder().addTraces(trace).build());
     }
   }
 }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/LoggingTraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/LoggingTraceSink.java
@@ -14,7 +14,7 @@
 
 package com.google.cloud.trace.v1.sink;
 
-import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.Traces;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
  *
  * @see Level
  * @see Logger
- * @see Trace
+ * @see Traces
  * @see TraceSink
  */
 public class LoggingTraceSink implements TraceSink {
@@ -42,7 +42,7 @@ public class LoggingTraceSink implements TraceSink {
   }
 
   @Override
-  public void receive(Trace trace) {
-    logger.log(level, "Received trace: " + trace);
+  public void receive(Traces traces) {
+    logger.log(level, "Received traces: " + traces);
   }
 }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/ScheduledBufferingTraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/ScheduledBufferingTraceSink.java
@@ -16,7 +16,6 @@ package com.google.cloud.trace.v1.sink;
 
 import com.google.cloud.trace.v1.util.Sizer;
 import com.google.cloud.trace.v1.util.TraceBuffer;
-import com.google.common.collect.ImmutableList;
 import com.google.devtools.cloudtrace.v1.Trace;
 import com.google.devtools.cloudtrace.v1.Traces;
 import java.util.concurrent.Future;
@@ -31,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @see FlushableTraceSink
  * @see Sizer
- * @see Trace
+ * @see Traces
  * @see TraceSink
  */
 public class ScheduledBufferingTraceSink implements FlushableTraceSink {
@@ -68,17 +67,19 @@ public class ScheduledBufferingTraceSink implements FlushableTraceSink {
   }
 
   @Override
-  public void receive(Trace trace) {
+  public void receive(Traces traces) {
     synchronized(monitor) {
-      traceBuffer.put(trace);
-      size += traceSizer.size(trace);
-      if (size >= bufferSize) {
-        if (autoFlusher == null) {
-          autoFlusher = scheduler.submit(flushable());
-        }
-      } else {
-        if ((flusher == null) && (autoFlusher == null)) {
-          flusher = scheduler.schedule(flushable(), scheduledDelay, TimeUnit.SECONDS);
+      for (Trace trace : traces.getTracesList()) {
+        traceBuffer.put(trace);
+        size += traceSizer.size(trace);
+        if (size >= bufferSize) {
+          if (autoFlusher == null) {
+            autoFlusher = scheduler.submit(flushable());
+          }
+        } else {
+          if ((flusher == null) && (autoFlusher == null)) {
+            flusher = scheduler.schedule(flushable(), scheduledDelay, TimeUnit.SECONDS);
+          }
         }
       }
     }
@@ -100,9 +101,7 @@ public class ScheduledBufferingTraceSink implements FlushableTraceSink {
         flusher = null;
       }
     }
-    for (Trace trace : traces.getTracesList()) {
-      traceSink.receive(trace);
-    }
+    traceSink.receive(traces);
   }
 
   private Runnable flushable() {

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/ScheduledBufferingTraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/ScheduledBufferingTraceSink.java
@@ -18,6 +18,7 @@ import com.google.cloud.trace.v1.util.Sizer;
 import com.google.cloud.trace.v1.util.TraceBuffer;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.Traces;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -85,9 +86,9 @@ public class ScheduledBufferingTraceSink implements FlushableTraceSink {
 
   @Override
   public void flush() {
-    ImmutableList<Trace> traces;
+    Traces traces;
     synchronized(monitor) {
-      traces = ImmutableList.copyOf(traceBuffer.getTraces());
+      traces = traceBuffer.getTraces();
       traceBuffer.clear();
       size = 0;
       if (autoFlusher != null) {
@@ -99,7 +100,7 @@ public class ScheduledBufferingTraceSink implements FlushableTraceSink {
         flusher = null;
       }
     }
-    for (Trace trace : traces) {
+    for (Trace trace : traces.getTracesList()) {
       traceSink.receive(trace);
     }
   }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SimpleBufferingTraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SimpleBufferingTraceSink.java
@@ -29,7 +29,7 @@ import com.google.devtools.cloudtrace.v1.Traces;
  */
 public class SimpleBufferingTraceSink implements FlushableTraceSink {
   private final TraceSink traceSink;
-  private final TraceBuffer traceBuffer;
+  private TraceBuffer traceBuffer;
 
   private final Object monitor = new Object();
 
@@ -54,11 +54,14 @@ public class SimpleBufferingTraceSink implements FlushableTraceSink {
 
   @Override
   public void flush() {
-    Traces traces;
+    TraceBuffer previous;
     synchronized(monitor) {
-      traces = traceBuffer.getTraces();
-      traceBuffer.clear();
+      previous = traceBuffer;
+      traceBuffer = new TraceBuffer();
     }
-    traceSink.receive(traces);
+    if (!previous.isEmpty()) {
+      Traces traces = previous.getTraces();
+      traceSink.receive(traces);
+    }
   }
 }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SimpleBufferingTraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SimpleBufferingTraceSink.java
@@ -16,6 +16,7 @@ package com.google.cloud.trace.v1.sink;
 
 import com.google.cloud.trace.v1.util.TraceBuffer;
 import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.Traces;
 
 /**
  * A trace sink that buffers trace messages until it is flushed. When flushed, this sink sends its
@@ -51,10 +52,12 @@ public class SimpleBufferingTraceSink implements FlushableTraceSink {
 
   @Override
   public void flush() {
+    Traces traces;
     synchronized(monitor) {
-      for (Trace trace : traceBuffer.getTraces()) {
-        traceSink.receive(trace);
-      }
+      traces = traceBuffer.getTraces();
+    }
+    for (Trace trace : traces.getTracesList()) {
+      traceSink.receive(trace);
     }
   }
 }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SimpleBufferingTraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SimpleBufferingTraceSink.java
@@ -24,7 +24,7 @@ import com.google.devtools.cloudtrace.v1.Traces;
  * thread-safe.
  *
  * @see FlushableTraceSink
- * @see Trace
+ * @see Traces
  * @see TraceSink
  */
 public class SimpleBufferingTraceSink implements FlushableTraceSink {
@@ -44,9 +44,11 @@ public class SimpleBufferingTraceSink implements FlushableTraceSink {
   }
 
   @Override
-  public void receive(Trace trace) {
+  public void receive(Traces traces) {
     synchronized(monitor) {
-      traceBuffer.put(trace);
+      for (Trace trace : traces.getTracesList()) {
+        traceBuffer.put(trace);
+      }
     }
   }
 
@@ -56,8 +58,6 @@ public class SimpleBufferingTraceSink implements FlushableTraceSink {
     synchronized(monitor) {
       traces = traceBuffer.getTraces();
     }
-    for (Trace trace : traces.getTracesList()) {
-      traceSink.receive(trace);
-    }
+    traceSink.receive(traces);
   }
 }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SimpleBufferingTraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SimpleBufferingTraceSink.java
@@ -57,6 +57,7 @@ public class SimpleBufferingTraceSink implements FlushableTraceSink {
     Traces traces;
     synchronized(monitor) {
       traces = traceBuffer.getTraces();
+      traceBuffer.clear();
     }
     traceSink.receive(traces);
   }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SizedBufferingTraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SizedBufferingTraceSink.java
@@ -26,7 +26,7 @@ import com.google.devtools.cloudtrace.v1.Traces;
  *
  * @see FlushableTraceSink
  * @see Sizer
- * @see Trace
+ * @see Traces
  * @see TraceSink
  */
 public class SizedBufferingTraceSink implements FlushableTraceSink {
@@ -55,12 +55,14 @@ public class SizedBufferingTraceSink implements FlushableTraceSink {
   }
 
   @Override
-  public void receive(Trace trace) {
+  public void receive(Traces traces) {
     synchronized(monitor) {
-      size += traceSizer.size(trace);
-      traceBuffer.put(trace);
-      if (size >= bufferSize) {
-        flush();
+      for (Trace trace : traces.getTracesList()) {
+        size += traceSizer.size(trace);
+        traceBuffer.put(trace);
+        if (size >= bufferSize) {
+          flush();
+        }
       }
     }
   }
@@ -73,8 +75,6 @@ public class SizedBufferingTraceSink implements FlushableTraceSink {
       traceBuffer.clear();
       size = 0;
     }
-    for (Trace trace : traces.getTracesList()) {
-      traceSink.receive(trace);
-    }
+    traceSink.receive(traces);
   }
 }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SizedBufferingTraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SizedBufferingTraceSink.java
@@ -33,7 +33,7 @@ public class SizedBufferingTraceSink implements FlushableTraceSink {
   private final TraceSink traceSink;
   private final Sizer<Trace> traceSizer;
   private final int bufferSize;
-  private final TraceBuffer traceBuffer;
+  private TraceBuffer traceBuffer;
 
   private int size;
 
@@ -69,12 +69,15 @@ public class SizedBufferingTraceSink implements FlushableTraceSink {
 
   @Override
   public void flush() {
-    Traces traces;
+    TraceBuffer previous;
     synchronized(monitor) {
-      traces = traceBuffer.getTraces();
-      traceBuffer.clear();
+      previous = traceBuffer;
+      traceBuffer = new TraceBuffer();
       size = 0;
     }
-    traceSink.receive(traces);
+    if (!previous.isEmpty()) {
+      Traces traces = previous.getTraces();
+      traceSink.receive(traces);
+    }
   }
 }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SizedBufferingTraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/SizedBufferingTraceSink.java
@@ -17,6 +17,7 @@ package com.google.cloud.trace.v1.sink;
 import com.google.cloud.trace.v1.util.Sizer;
 import com.google.cloud.trace.v1.util.TraceBuffer;
 import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.Traces;
 
 /**
  * A flushable trace sink that auto-flushes when its buffered trace messages exceed its buffer size.
@@ -66,12 +67,14 @@ public class SizedBufferingTraceSink implements FlushableTraceSink {
 
   @Override
   public void flush() {
+    Traces traces;
     synchronized(monitor) {
-      for (Trace trace : traceBuffer.getTraces()) {
-        traceSink.receive(trace);
-      }
+      traces = traceBuffer.getTraces();
       traceBuffer.clear();
       size = 0;
+    }
+    for (Trace trace : traces.getTracesList()) {
+      traceSink.receive(trace);
     }
   }
 }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/TraceSink.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/sink/TraceSink.java
@@ -15,6 +15,7 @@
 package com.google.cloud.trace.v1.sink;
 
 import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.Traces;
 
 /**
  * An interface for a trace sink that accepts Stackdriver Trace API v1 trace messages.
@@ -27,5 +28,5 @@ public interface TraceSink {
    *
    * @param trace a trace that is accepted by this sink.
    */
-  void receive(Trace trace);
+  void receive(Traces trace);
 }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/util/TraceBuffer.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/util/TraceBuffer.java
@@ -75,9 +75,9 @@ public class TraceBuffer {
   }
 
   /**
-   * Removes all of the trace messages from this trace buffer.
+   * Returns true if the TraceBuffer is empty.
    */
-  public void clear() {
-    traceMap.clear();
+  public boolean isEmpty() {
+    return traceMap.isEmpty();
   }
 }

--- a/sdk/v1/src/main/java/com/google/cloud/trace/v1/util/TraceBuffer.java
+++ b/sdk/v1/src/main/java/com/google/cloud/trace/v1/util/TraceBuffer.java
@@ -14,10 +14,9 @@
 
 package com.google.cloud.trace.v1.util;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
 import com.google.devtools.cloudtrace.v1.Trace;
 import com.google.devtools.cloudtrace.v1.TraceSpan;
+import com.google.devtools.cloudtrace.v1.Traces;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +25,7 @@ import java.util.Map;
  * existing trace messages when they contain the same trace identifiers, by combining the spans of
  * the matching trace messages.
  *
- * @see Iterable
+ * @see Traces
  * @see Trace
  */
 public class TraceBuffer {
@@ -61,20 +60,18 @@ public class TraceBuffer {
    *
    * @return an iterable containing the trace messages in this trace buffer.
    */
-  public Iterable<Trace> getTraces() {
-    return Iterables.transform(traceMap.entrySet(),
-        new Function<Map.Entry<TraceKey, SpanBuffer>, Trace>(){
-      @Override
-      public Trace apply(Map.Entry<TraceKey, SpanBuffer> entry) {
-        Trace.Builder traceBuilder = Trace.newBuilder()
-            .setProjectId(entry.getKey().getProjectId())
-            .setTraceId(entry.getKey().getTraceId());
-        for (TraceSpan.Builder spanBuilder : entry.getValue().getSpans()) {
-          traceBuilder.addSpans(spanBuilder);
-        }
-        return traceBuilder.build();
+  public Traces getTraces() {
+    Traces.Builder tracesBuilder = Traces.newBuilder();
+    for (Map.Entry<TraceKey, SpanBuffer> entry : traceMap.entrySet()) {
+      Trace.Builder traceBuilder = Trace.newBuilder()
+          .setProjectId(entry.getKey().getProjectId())
+          .setTraceId(entry.getKey().getTraceId());
+      for (TraceSpan.Builder spanBuilder : entry.getValue().getSpans()) {
+        traceBuilder.addSpans(spanBuilder);
       }
-    });
+      tracesBuilder.addTraces(traceBuilder);
+    }
+    return tracesBuilder.build();
   }
 
   /**

--- a/sdk/v1/src/test/java/com/google/cloud/trace/v1/sink/SimpleBufferingTraceSinkTest.java
+++ b/sdk/v1/src/test/java/com/google/cloud/trace/v1/sink/SimpleBufferingTraceSinkTest.java
@@ -1,0 +1,37 @@
+package com.google.cloud.trace.v1.sink;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.Traces;
+import java.util.List;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class SimpleBufferingTraceSinkTest {
+
+  @Test
+  public void testBuffering() {
+    ArgumentCaptor<Traces> tracesCaptor = ArgumentCaptor.forClass(Traces.class);
+    TraceSink mockSink = mock(TraceSink.class);
+    FlushableTraceSink bufferedSink = new SimpleBufferingTraceSink(mockSink);
+    Trace trace1 = Trace.newBuilder().setProjectId("1").setTraceId("1").build();
+    Trace trace2 = Trace.newBuilder().setProjectId("1").setTraceId("2").build();
+    Trace trace3 = Trace.newBuilder().setProjectId("1").setTraceId("3").build();
+    bufferedSink.receive(Traces.newBuilder().addTraces(trace1).build());
+    bufferedSink.receive(Traces.newBuilder().addTraces(trace2).build());
+    bufferedSink.flush();
+    bufferedSink.receive(Traces.newBuilder().addTraces(trace3).build());
+    bufferedSink.flush();
+
+    verify(mockSink, times(2)).receive(tracesCaptor.capture());
+    List<Traces> traceBatches = tracesCaptor.getAllValues();
+    assertThat(traceBatches).hasSize(2);
+    assertThat(traceBatches.get(0).getTracesList()).containsExactly(trace1, trace2);
+    assertThat(traceBatches.get(1).getTracesList()).containsExactly(trace3);
+  }
+
+}

--- a/sdk/v1/src/test/java/com/google/cloud/trace/v1/sink/SizedBufferingTraceSinkTest.java
+++ b/sdk/v1/src/test/java/com/google/cloud/trace/v1/sink/SizedBufferingTraceSinkTest.java
@@ -1,0 +1,55 @@
+package com.google.cloud.trace.v1.sink;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.trace.v1.util.Sizer;
+import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.Traces;
+import java.util.List;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class SizedBufferingTraceSinkTest {
+
+  @Test
+  public void testBuffering() {
+    ArgumentCaptor<Traces> tracesCaptor = ArgumentCaptor.forClass(Traces.class);
+    TraceSink mockSink = mock(TraceSink.class);
+    final Trace trace1 = Trace.newBuilder().setProjectId("1").setTraceId("1").build();
+    final Trace trace2 = Trace.newBuilder().setProjectId("1").setTraceId("2").build();
+    final Trace trace3 = Trace.newBuilder().setProjectId("1").setTraceId("3").build();
+    Sizer<Trace> testSizer = new Sizer<Trace>() {
+
+      @Override
+      public int size(Trace sizeable) {
+        if (sizeable == trace1) {
+          return 10;
+        } else if (sizeable == trace2) {
+          return 20;
+        } else if (sizeable == trace3) {
+          return 30;
+        } else {
+          return 0;
+        }
+      }
+    };
+
+    FlushableTraceSink bufferedSink = new SizedBufferingTraceSink(mockSink, testSizer, 25);
+    bufferedSink.receive(Traces.newBuilder().addTraces(trace1).build()); // buffer size: 10
+    bufferedSink.receive(Traces.newBuilder().addTraces(trace2).build()); // buffer size: 30
+    // should flush
+
+    bufferedSink.receive(Traces.newBuilder().addTraces(trace3).build()); // buffer size: 30
+    // should flush
+
+    verify(mockSink, times(2)).receive(tracesCaptor.capture());
+    List<Traces> traceBatches = tracesCaptor.getAllValues();
+
+    assertThat(traceBatches).hasSize(2);
+    assertThat(traceBatches.get(0).getTracesList()).containsExactly(trace1, trace2);
+    assertThat(traceBatches.get(1).getTracesList()).containsExactly(trace3);
+  }
+}


### PR DESCRIPTION
Changing TraceSink interface to accept Traces instead of Trace.

This will make the buffering Sinks more effective because they will be able to send batches of Traces to their delegate Sinks instead of making a call for each individual Trace. This should translate into fewer calls being made to the Stackdriver Trace API.