### PR TITLE
Adding TraceContextSwapper

### DIFF
--- a/sdk/core/src/main/java/com/google/cloud/trace/ThreadLocalTraceContextSwapper.java
+++ b/sdk/core/src/main/java/com/google/cloud/trace/ThreadLocalTraceContextSwapper.java
@@ -1,0 +1,60 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.trace;
+
+import com.google.cloud.trace.util.TraceContext;
+
+/**
+ * An implementation of TraceContextSwapper that uses ThreadLocal storage to store TraceContextHandlers.
+ *
+ * A server-side RPC interceptor may use this to swap the TraceContextHandler so that a request
+ * uses the {@link com.google.cloud.trace.util.TraceContext} provided in an HTTP header.
+ * An {@link java.util.concurrent.Executor} may use this to swap the {@link TraceContextHandler} so
+ * that children threads inherit the context from their parent thread.
+ */
+public class ThreadLocalTraceContextSwapper implements TraceContextSwapper {
+  private static final ThreadLocal<TraceContextHandler> handlers = new ThreadLocal<TraceContextHandler>();
+  private final TraceContext defaultRoot;
+
+  /**
+   * Creates a new TraceContextSwapper
+   * @param defaultRoot The default root TraceContext that should be used for each Thread.
+   */
+  public ThreadLocalTraceContextSwapper(TraceContext defaultRoot) {
+    this.defaultRoot = defaultRoot;
+  }
+
+  @Override
+  public TraceContextHandler swap(TraceContextHandler newHandler) {
+    TraceContextHandler previousHandler = currentHandler();
+    handlers.set(newHandler);
+    return previousHandler;
+  }
+
+  /**
+   * Returns the current trace context handler for the current thread.
+   *
+   * @return the current trace context handler.
+   */
+  @Override
+  public TraceContextHandler currentHandler() {
+    TraceContextHandler handler = handlers.get();
+    if (handler == null) {
+      handler = new DefaultTraceContextHandler(defaultRoot);
+      handlers.set(handler);
+    }
+    return handler;
+  }
+}

--- a/sdk/core/src/main/java/com/google/cloud/trace/TraceContextSwapper.java
+++ b/sdk/core/src/main/java/com/google/cloud/trace/TraceContextSwapper.java
@@ -1,0 +1,33 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.trace;
+
+/**
+ * An interface used for swapping {@link TraceContextHandler}s.
+ */
+public interface TraceContextSwapper {
+
+  /**
+   * Swap the current {@link TraceContextHandler} with the provided {@link TraceContextHandler}
+   * @param newHandler The new {@link TraceContextHandler}
+   * @return The previous {@link TraceContextHandler}
+   */
+  TraceContextHandler swap(TraceContextHandler newHandler);
+
+  /**
+   * @return The current {@link TraceContextHandler}
+   */
+  TraceContextHandler currentHandler();
+}

--- a/sdk/core/src/main/java/com/google/cloud/trace/TraceContextSwapperTracer.java
+++ b/sdk/core/src/main/java/com/google/cloud/trace/TraceContextSwapperTracer.java
@@ -1,0 +1,78 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.trace;
+
+import com.google.cloud.trace.util.EndSpanOptions;
+import com.google.cloud.trace.util.Labels;
+import com.google.cloud.trace.util.StackTrace;
+import com.google.cloud.trace.util.StartSpanOptions;
+import com.google.cloud.trace.util.TraceContext;
+
+public class TraceContextSwapperTracer implements ManagedTracer {
+  private final Tracer tracer;
+  private final TraceContextSwapper contextSwapper;
+
+  public TraceContextSwapperTracer(Tracer tracer, TraceContextSwapper contextSwapper) {
+    this.tracer = tracer;
+    this.contextSwapper = contextSwapper;
+  }
+
+  @Override
+  public void startSpan(String name) {
+    TraceContextHandler contextHandler = getContextHandler();
+    TraceContext context = tracer.startSpan(contextHandler.current(), name);
+    contextHandler.push(context);
+  }
+
+  @Override
+  public void startSpan(String name, StartSpanOptions options) {
+    TraceContextHandler contextHandler = getContextHandler();
+    TraceContext context = tracer.startSpan(contextHandler.current(), name, options);
+    contextHandler.push(context);
+  }
+
+  @Override
+  public void endSpan() {
+    TraceContextHandler contextHandler = getContextHandler();
+    tracer.endSpan(contextHandler.current());
+    contextHandler.pop();
+  }
+
+  @Override
+  public void endSpan(EndSpanOptions options) {
+    TraceContextHandler contextHandler = getContextHandler();
+    tracer.endSpan(contextHandler.current(), options);
+    contextHandler.pop();
+  }
+
+  @Override
+  public void annotateSpan(Labels labels) {
+    tracer.annotateSpan(getContextHandler().current(), labels);
+  }
+
+  @Override
+  public void setStackTrace(StackTrace stackTrace) {
+    tracer.setStackTrace(getContextHandler().current(), stackTrace);
+  }
+
+  @Override
+  public TraceContext getCurrentTraceContext() {
+    return getContextHandler().current();
+  }
+
+  private TraceContextHandler getContextHandler() {
+    return contextSwapper.currentHandler();
+  }
+}

--- a/sdk/core/src/test/java/com/google/cloud/trace/DefaultTraceContextHandlerTest.java
+++ b/sdk/core/src/test/java/com/google/cloud/trace/DefaultTraceContextHandlerTest.java
@@ -1,0 +1,47 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.trace;
+
+import static org.junit.Assert.assertSame;
+
+import com.google.cloud.trace.util.SpanId;
+import com.google.cloud.trace.util.TraceContext;
+import com.google.cloud.trace.util.TraceId;
+import com.google.cloud.trace.util.TraceOptions;
+import java.math.BigInteger;
+import org.junit.Test;
+
+public class DefaultTraceContextHandlerTest {
+
+  @Test
+  public void testPushPop() {
+    TraceContext root = new TraceContext(new TraceId(BigInteger.valueOf(3)), new SpanId(4),
+        TraceOptions.forTraceEnabled());
+    TraceContext child1 = new TraceContext(new TraceId(BigInteger.valueOf(3)), new SpanId(5),
+        TraceOptions.forTraceEnabled());
+    TraceContext child2 = new TraceContext(new TraceId(BigInteger.valueOf(3)), new SpanId(6),
+        TraceOptions.forTraceEnabled());
+
+    TraceContextHandler handler = new DefaultTraceContextHandler(root);
+
+    assertSame(root, handler.current());
+    handler.push(child1);
+    assertSame(child1, handler.current());
+    handler.push(child2);
+    assertSame(child2, handler.current());
+    handler.pop();
+    assertSame(child1, handler.current());
+  }
+}

--- a/sdk/core/src/test/java/com/google/cloud/trace/ThreadLocalTraceContextSwapperTest.java
+++ b/sdk/core/src/test/java/com/google/cloud/trace/ThreadLocalTraceContextSwapperTest.java
@@ -1,0 +1,111 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.trace;
+
+import static org.junit.Assert.assertSame;
+
+import com.google.cloud.trace.util.SpanId;
+import com.google.cloud.trace.util.TraceContext;
+import com.google.cloud.trace.util.TraceId;
+import com.google.cloud.trace.util.TraceOptions;
+import java.math.BigInteger;
+import org.junit.Test;
+
+public class ThreadLocalTraceContextSwapperTest {
+
+  @Test
+  public void testTwoThreads() {
+    final TraceContext defaultRoot = new TraceContext(new TraceId(BigInteger.valueOf(2)), new SpanId(3), TraceOptions.forTraceEnabled());
+    final TraceContext root1 = new TraceContext(new TraceId(BigInteger.valueOf(3)), new SpanId(4), TraceOptions.forTraceEnabled());
+    final TraceContext child1 = new TraceContext(new TraceId(BigInteger.valueOf(3)), new SpanId(5), TraceOptions.forTraceEnabled());
+    final TraceContext root2 = new TraceContext(new TraceId(BigInteger.valueOf(4)), new SpanId(5), TraceOptions.forTraceDisabled());
+    final TraceContext child2 = new TraceContext(new TraceId(BigInteger.valueOf(4)), new SpanId(6), TraceOptions.forTraceEnabled());
+
+    final ThreadLocalTraceContextSwapper swapper = new ThreadLocalTraceContextSwapper(defaultRoot);
+
+    assertSame(defaultRoot, swapper.currentHandler().current());
+    TraceContextHandler newHandler = new DefaultTraceContextHandler(root1);
+    TraceContextHandler previousHandler = swapper.swap(newHandler);
+    assertSame(newHandler, swapper.currentHandler());
+    swapper.currentHandler().push(child1);
+
+    ThreadRunnable runnable = new ThreadRunnable(swapper, root2, child2);
+    Thread thread2 = new Thread(runnable);
+    thread2.start();
+    try {
+      thread2.join();
+    } catch (InterruptedException e) {
+      // Do nothing.
+    }
+
+    // Check the current thread context is still there.
+    TraceContextHandler currentHandler = swapper.currentHandler();
+    assertSame(child1, currentHandler.current());
+    assertSame(child1, currentHandler.pop());
+    assertSame(root1, currentHandler.current());
+
+    // Check the results from the other thread.
+    assertSame(defaultRoot, runnable.initialContext);
+    assertSame(root2, runnable.contextAfterAttach);
+    assertSame(child2, runnable.contextAfterPush);
+    assertSame(root2, runnable.contextAfterPop);
+    assertSame(defaultRoot, runnable.contextAfterDetach);
+
+    // Detach the context handler from the current thread.
+    swapper.swap(previousHandler);
+    assertSame(previousHandler, swapper.currentHandler());
+
+    // Swap in a null context handler and ensure push() still works.
+    swapper.swap(null);
+    swapper.currentHandler().push(child1);
+    assertSame(child1, swapper.currentHandler().current());
+
+    // Swap in a null context handler and ensure it returns the default root.
+    swapper.swap(null);
+    assertSame(defaultRoot, swapper.currentHandler().current());
+  }
+
+  private static class ThreadRunnable implements Runnable {
+
+    private final ThreadLocalTraceContextSwapper swapper;
+    private final TraceContext rootToAttach;
+    private final TraceContext toPush;
+    TraceContext initialContext;
+    TraceContext contextAfterAttach;
+    TraceContext contextAfterPush;
+    TraceContext contextAfterPop;
+    TraceContext contextAfterDetach;
+
+    ThreadRunnable(ThreadLocalTraceContextSwapper swapper, TraceContext rootToAttach, TraceContext toPush) {
+      this.swapper = swapper;
+      this.rootToAttach = rootToAttach;
+      this.toPush = toPush;
+    }
+
+    @Override
+    public void run() {
+      initialContext = swapper.currentHandler().current();
+      TraceContextHandler previous = swapper.swap(new DefaultTraceContextHandler(rootToAttach));
+      contextAfterAttach = swapper.currentHandler().current();
+      swapper.currentHandler().push(toPush);
+      contextAfterPush = swapper.currentHandler().current();
+      swapper.currentHandler().pop();
+      contextAfterPop = swapper.currentHandler().current();
+      swapper.swap(previous);
+      contextAfterDetach = swapper.currentHandler().current();
+    }
+  }
+
+}

--- a/sdk/core/src/test/java/com/google/cloud/trace/TraceContextSwapperTracerTest.java
+++ b/sdk/core/src/test/java/com/google/cloud/trace/TraceContextSwapperTracerTest.java
@@ -1,0 +1,190 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.trace.util.EndSpanOptions;
+import com.google.cloud.trace.util.Labels;
+import com.google.cloud.trace.util.SpanId;
+import com.google.cloud.trace.util.StackTrace;
+import com.google.cloud.trace.util.StartSpanOptions;
+import com.google.cloud.trace.util.TraceContext;
+import com.google.cloud.trace.util.TraceId;
+import com.google.cloud.trace.util.TraceOptions;
+import java.math.BigInteger;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TraceContextSwapperTracerTest {
+
+  private Tracer fakeTracer;
+  private TraceContext root1;
+  private TraceContext root2;
+  private TraceContext newContext1;
+  private TraceContext newContext2;
+  private TraceContextHandler handler1;
+  private TraceContextHandler handler2;
+  private TraceContextSwapper swapper;
+  private TraceContextSwapperTracer tracer;
+
+  @Before
+  public void setup() {
+    fakeTracer = mock(Tracer.class);
+    root1 = new TraceContext(new TraceId(BigInteger.valueOf(3)), new SpanId(4), TraceOptions.forTraceEnabled());
+    root2 = new TraceContext(new TraceId(BigInteger.valueOf(4)), new SpanId(5), TraceOptions.forTraceDisabled());
+    newContext1 = new TraceContext(new TraceId(BigInteger.valueOf(3)), new SpanId(6), TraceOptions.forTraceEnabled());
+    newContext2 = new TraceContext(new TraceId(BigInteger.valueOf(4)), new SpanId(6), TraceOptions.forTraceEnabled());
+
+    handler1 = new DefaultTraceContextHandler(root1);
+    handler2 = new DefaultTraceContextHandler(root2);
+    swapper = new TestContextSwapper();
+    swapper.swap(handler1);
+    tracer = new TraceContextSwapperTracer(fakeTracer, swapper);
+  }
+
+  @Test
+  public void testStartAndEndSpan() throws Exception {
+
+    // Start a new span
+    when(fakeTracer.startSpan(root1, "foo")).thenReturn(newContext1);
+    tracer.startSpan("foo");
+    assertThat(handler1.current()).isSameAs(newContext1);
+    assertThat(tracer.getCurrentTraceContext()).isSameAs(handler1.current());
+    verify(fakeTracer).startSpan(root1, "foo");
+
+    // Swap the context handler
+    swapper.swap(handler2);
+
+    // Start a new span
+    when(fakeTracer.startSpan(root2, "bar")).thenReturn(newContext2);
+    tracer.startSpan("bar");
+    assertThat(handler2.current()).isSameAs(newContext2);
+    assertThat(tracer.getCurrentTraceContext()).isSameAs(handler2.current());
+    verify(fakeTracer).startSpan(root2, "bar");
+
+    // End the span
+    tracer.endSpan();
+    assertThat(handler2.current()).isSameAs(root2);
+    assertThat(tracer.getCurrentTraceContext()).isSameAs(handler2.current());
+    verify(fakeTracer).endSpan(newContext2);
+
+    // Swap the context handler again
+    swapper.swap(handler1);
+
+    // End the span
+    tracer.endSpan();
+    assertThat(handler1.current()).isSameAs(root1);
+    assertThat(tracer.getCurrentTraceContext()).isSameAs(handler1.current());
+    verify(fakeTracer).endSpan(newContext1);
+  }
+
+  @Test
+  public void testStartAndEndSpanWithOptions() throws Exception {
+    StartSpanOptions startOptions;
+    // Start a new span
+    startOptions = new StartSpanOptions();
+    when(fakeTracer.startSpan(root1, "foo", startOptions)).thenReturn(newContext1);
+    tracer.startSpan("foo", startOptions);
+    assertThat(handler1.current()).isSameAs(newContext1);
+    verify(fakeTracer).startSpan(same(root1), eq("foo"), same(startOptions));
+
+    // Swap the context handler
+    swapper.swap(handler2);
+
+    // Start a new span
+    startOptions = new StartSpanOptions();
+    when(fakeTracer.startSpan(root2, "bar", startOptions)).thenReturn(newContext2);
+    tracer.startSpan("bar", startOptions);
+    assertThat(handler2.current()).isSameAs(newContext2);
+    verify(fakeTracer).startSpan(same(root2), eq("bar"), same(startOptions));
+
+    EndSpanOptions endOptions;
+    // End the span
+    endOptions = new EndSpanOptions();
+    tracer.endSpan(endOptions);
+    assertThat(handler2.current()).isSameAs(root2);
+    verify(fakeTracer).endSpan(same(newContext2), same(endOptions));
+
+    // Swap the context handler again
+    swapper.swap(handler1);
+
+    // End the span
+    endOptions = new EndSpanOptions();
+    tracer.endSpan(endOptions);
+    assertThat(handler1.current()).isSameAs(root1);
+    verify(fakeTracer).endSpan(same(newContext1), same(endOptions));
+  }
+
+  @Test
+  public void annotateSpan() throws Exception {
+    Labels labels1 = Labels.builder().add("key1", "value1").build();
+    Labels labels2 = Labels.builder().add("key2", "value2").build();
+
+    // Annotate span
+    tracer.annotateSpan(labels1);
+    verify(fakeTracer).annotateSpan(same(root1), same(labels1));
+
+    // Swap the context handler
+    swapper.swap(handler2);
+
+    // Annotate span
+    tracer.annotateSpan(labels2);
+    verify(fakeTracer).annotateSpan(same(root2), same(labels2));
+  }
+
+  @Test
+  public void setStackTrace() throws Exception {
+    StackTrace stackTrace1 = StackTrace.builder().build();
+    StackTrace stackTrace2 = StackTrace.builder().build();
+
+    // Annotate span
+    tracer.setStackTrace(stackTrace1);
+    verify(fakeTracer).setStackTrace(same(root1), same(stackTrace1));
+
+    // Swap the context handler
+    swapper.swap(handler2);
+
+    // Annotate span
+    tracer.setStackTrace(stackTrace2);
+    verify(fakeTracer).setStackTrace(same(root2), same(stackTrace2));
+
+  }
+
+  private static class TestContextSwapper implements TraceContextSwapper {
+    private TraceContextHandler handler;
+
+    private TestContextSwapper() {
+      this.handler = null;
+    }
+
+    @Override
+    public TraceContextHandler swap(TraceContextHandler newHandler) {
+      TraceContextHandler previous = handler;
+      handler = newHandler;
+      return previous;
+    }
+
+    @Override
+    public TraceContextHandler currentHandler() {
+      return handler;
+    }
+  }
+}

--- a/sdk/guice/core/src/main/java/com/google/cloud/trace/guice/ThreadLocalTraceContextSwapperModule.java
+++ b/sdk/guice/core/src/main/java/com/google/cloud/trace/guice/ThreadLocalTraceContextSwapperModule.java
@@ -1,0 +1,33 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.trace.guice;
+
+import com.google.cloud.trace.ThreadLocalTraceContextSwapper;
+import com.google.cloud.trace.TraceContextSwapper;
+import com.google.cloud.trace.util.TraceContextFactory;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+
+public class ThreadLocalTraceContextSwapperModule extends AbstractModule {
+  @Override
+  protected void configure() {}
+
+  @Provides
+  @Singleton
+  TraceContextSwapper provideSwapper(TraceContextFactory traceContextFactory) {
+    return new ThreadLocalTraceContextSwapper(traceContextFactory.rootContext());
+  }
+}

--- a/sdk/guice/core/src/main/java/com/google/cloud/trace/guice/TraceContextSwapperTracerModule.java
+++ b/sdk/guice/core/src/main/java/com/google/cloud/trace/guice/TraceContextSwapperTracerModule.java
@@ -1,0 +1,34 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.trace.guice;
+
+import com.google.cloud.trace.ManagedTracer;
+import com.google.cloud.trace.TraceContextSwapper;
+import com.google.cloud.trace.TraceContextSwapperTracer;
+import com.google.cloud.trace.Tracer;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+
+public class TraceContextSwapperTracerModule extends AbstractModule {
+  @Override
+  protected void configure() {}
+
+  @Provides
+  @Singleton
+  ManagedTracer provideTracer(Tracer tracer, TraceContextSwapper contextSwapper) {
+    return new TraceContextSwapperTracer(tracer, contextSwapper);
+  }
+}


### PR DESCRIPTION
Adding a TraceContextSwapper interface and ThreadLocalTraceContextSwapper and TraceContextSwapperTracer implementations. This can be used by instrumentation to swap the TraceContextHandler used by the current thread. 

A Servlet filter may use this to initialize the TraceContext for the request. An Executor may use this to propagate TraceContext across threads.