### PR TITLE
Make TraceContextFactory.childContext() make a sampling decision

### DIFF
--- a/samples/basic-logging/src/main/java/com/google/cloud/trace/samples/logging/basic/BasicLogging.java
+++ b/samples/basic-logging/src/main/java/com/google/cloud/trace/samples/logging/basic/BasicLogging.java
@@ -48,7 +48,7 @@ public class BasicLogging {
     Tracer tracer = new TraceContextFactoryTracer(rawTracer, traceContextFactory, timestampFactory);
 
     // Create a span using the given timestamps.
-    TraceContext context1 = tracer.startSpan(traceContextFactory.rootContext(), "my span 1");
+    TraceContext context1 = tracer.startSpan(traceContextFactory.initialContext(), "my span 1");
     StackTrace.Builder stackTraceBuilder = ThrowableStackTraceHelper.createBuilder(new Exception());
     tracer.setStackTrace(context1, stackTraceBuilder.build());
     tracer.endSpan(context1);

--- a/samples/buffering-grpc/src/main/java/com/google/cloud/trace/samples/grpc/buffering/SimpleBufferingGrpc.java
+++ b/samples/buffering-grpc/src/main/java/com/google/cloud/trace/samples/grpc/buffering/SimpleBufferingGrpc.java
@@ -55,7 +55,7 @@ public class SimpleBufferingGrpc {
     Tracer tracer = new TraceContextFactoryTracer(rawTracer, traceContextFactory, timestampFactory);
 
     // Create a span using the given timestamps.
-    TraceContext context1 = tracer.startSpan(traceContextFactory.rootContext(), "my span 1");
+    TraceContext context1 = tracer.startSpan(traceContextFactory.initialContext(), "my span 1");
 
     TraceContext context2 = tracer.startSpan(context1, "my span 2");
 

--- a/samples/managed-grpc/src/main/java/com/google/cloud/trace/samples/grpc/managed/ManagedGrpc.java
+++ b/samples/managed-grpc/src/main/java/com/google/cloud/trace/samples/grpc/managed/ManagedGrpc.java
@@ -56,7 +56,7 @@ public class ManagedGrpc {
 
     // Create the managed tracer.
     TraceContextHandler traceContextHandler = new DefaultTraceContextHandler(
-        traceContextFactory.rootContext());
+        traceContextFactory.initialContext());
     ManagedTracer managedTracer = new TraceContextHandlerTracer(tracer, traceContextHandler);
 
     // Create some trace data.

--- a/sdk/core/src/main/java/com/google/cloud/trace/util/TraceContextFactory.java
+++ b/sdk/core/src/main/java/com/google/cloud/trace/util/TraceContextFactory.java
@@ -70,7 +70,7 @@ public class TraceContextFactory {
   /**
    * Generates a new trace context based on the parent context with a new span identifier. If the
    * parent context has an invalid trace identifier, the new trace context will also have a new
-   * trace identifier.
+   * trace identifier, and a sampling decision will be made.
    *
    * @param parentContext a trace context that is the parent of the new trace context.
    * @return the new trace context.
@@ -81,7 +81,7 @@ public class TraceContextFactory {
           traceOptionsFactory.create(parentContext.getTraceOptions()));
     }
     return new TraceContext(traceIdFactory.nextId(), spanIdFactory.nextId(),
-        traceOptionsFactory.create(parentContext.getTraceOptions()));
+        traceOptionsFactory.create());
   }
 
   /**
@@ -93,17 +93,6 @@ public class TraceContextFactory {
    */
   public TraceContext initialContext() {
     return new TraceContext(traceIdFactory.invalid(), spanIdFactory.invalid(), new TraceOptions());
-  }
-
-  /**
-   * Generates a new trace context with invalid trace and span identifiers and new trace options.
-   * This method invokes the trace options factory, so a sampling decision is made.
-   *
-   * @return the new trace context.
-   */
-  public TraceContext rootContext() {
-    return new TraceContext(traceIdFactory.invalid(), spanIdFactory.invalid(),
-        traceOptionsFactory.create());
   }
 
   /**

--- a/sdk/core/src/test/java/com/google/cloud/trace/util/TraceContextFactoryTest.java
+++ b/sdk/core/src/test/java/com/google/cloud/trace/util/TraceContextFactoryTest.java
@@ -1,0 +1,99 @@
+package com.google.cloud.trace.util;
+
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.math.BigInteger;
+import org.junit.Test;
+
+public class TraceContextFactoryTest {
+
+  @Test
+  public void testChildContextWithInvalidParent() {
+    TestTraceOptionsFactory optionsFactory = new TestTraceOptionsFactory();
+    TraceContextFactory contextFactory = new TraceContextFactory(optionsFactory,
+        new SequentialTraceIdFactory(), new SequentialSpanIdFactory());
+    TraceContext initialContext = contextFactory.initialContext();
+
+    optionsFactory.toReturn = TraceOptions.forTraceEnabled();
+    TraceContext child1 = contextFactory.childContext(initialContext);
+    // The child context should have a valid Trace and Span Id.
+    assertThat(child1.getTraceId().isValid()).isTrue();
+    assertThat(child1.getSpanId().isValid()).isTrue();
+    // A sampling decision should be made.
+    assertThat(child1.getTraceOptions().getTraceEnabled()).isTrue();
+
+    optionsFactory.toReturn = TraceOptions.forTraceDisabled();
+    TraceContext child2 = contextFactory.childContext(initialContext);
+    // The child context should have a valid Trace and Span Id.
+    assertThat(child2.getTraceId().isValid()).isTrue();
+    assertThat(child2.getSpanId().isValid()).isTrue();
+    // A sampling decision should be made.
+    assertThat(child2.getTraceOptions().getTraceEnabled()).isFalse();
+
+    // Since child1 and child2 are both children of an invalid context, they should
+    // have different TraceIds
+    assertThat(child1.getTraceId().getTraceId()).isNotEqualTo(child2.getTraceId().getTraceId());
+  }
+
+  @Test
+  public void testChildContextWithValidParent() {
+    TestTraceOptionsFactory optionsFactory = new TestTraceOptionsFactory();
+    TraceContextFactory contextFactory = new TraceContextFactory(optionsFactory,
+        new SequentialTraceIdFactory(), new SequentialSpanIdFactory());
+    TraceContext initialContext = contextFactory.initialContext();
+
+    optionsFactory.toReturn = TraceOptions.forTraceEnabled();
+    TraceContext child1 = contextFactory.childContext(initialContext);
+    assertThat(child1.getTraceOptions().getTraceEnabled()).isTrue();
+
+    optionsFactory.toReturn = TraceOptions.forTraceDisabled();
+    TraceContext child2 = contextFactory.childContext(child1);
+
+    assertThat(child1.getTraceId()).isEqualTo(child2.getTraceId());
+    assertThat(child1.getSpanId()).isNotEqualTo(child2.getSpanId());
+    assertThat(child1.getTraceOptions()).isEqualTo(child2.getTraceOptions());
+  }
+
+  private static class SequentialTraceIdFactory implements IdFactory<TraceId> {
+    private long id = 1;
+
+    @Override
+    public TraceId nextId() {
+      return new TraceId(BigInteger.valueOf(id++));
+    }
+
+    @Override
+    public TraceId invalid() {
+      return new TraceId(BigInteger.valueOf(0));
+    }
+  }
+
+  private static class SequentialSpanIdFactory implements IdFactory<SpanId> {
+    private long id = 1;
+
+    @Override
+    public SpanId nextId() {
+      return new SpanId(id++);
+    }
+
+    @Override
+    public SpanId invalid() {
+      return new SpanId(0);
+    }
+  }
+
+  private static class TestTraceOptionsFactory implements TraceOptionsFactory {
+    TraceOptions toReturn = new TraceOptions();
+
+    @Override
+    public TraceOptions create() {
+      return toReturn;
+    }
+
+    @Override
+    public TraceOptions create(TraceOptions parent) {
+      return parent;
+    }
+  }
+}

--- a/sdk/guice/core/src/main/java/com/google/cloud/trace/guice/ThreadLocalTraceContextSwapperModule.java
+++ b/sdk/guice/core/src/main/java/com/google/cloud/trace/guice/ThreadLocalTraceContextSwapperModule.java
@@ -28,6 +28,6 @@ public class ThreadLocalTraceContextSwapperModule extends AbstractModule {
   @Provides
   @Singleton
   TraceContextSwapper provideSwapper(TraceContextFactory traceContextFactory) {
-    return new ThreadLocalTraceContextSwapper(traceContextFactory.rootContext());
+    return new ThreadLocalTraceContextSwapper(traceContextFactory.initialContext());
   }
 }

--- a/sdk/guice/servlet/src/main/java/com/google/cloud/trace/guice/servlet/RequestTraceContextFilter.java
+++ b/sdk/guice/servlet/src/main/java/com/google/cloud/trace/guice/servlet/RequestTraceContextFilter.java
@@ -57,7 +57,7 @@ public class RequestTraceContextFilter implements Filter {
     if (contextHeader != null) {
       context = traceContextFactory.fromHeader(contextHeader);
     } else {
-      context = traceContextFactory.rootContext();
+      context = traceContextFactory.initialContext();
     }
 
     httpRequest.setAttribute(


### PR DESCRIPTION
Make TraceContextFactory.childContext() make a sampling decision if the parent context is invalid and remove redundant TraceContextFactory.rootContext() method