### PR TITLE
Add replace() and restore() to TraceContextHandler

### DIFF
--- a/sdk/core/src/main/java/com/google/cloud/trace/ThreadLocalTraceContextHandler.java
+++ b/sdk/core/src/main/java/com/google/cloud/trace/ThreadLocalTraceContextHandler.java
@@ -40,6 +40,21 @@ public class ThreadLocalTraceContextHandler implements TraceContextHandler {
     return getHandler().pop();
   }
 
+  @Override
+  public TraceContextHandlerState replace() {
+    return getHandler().replace();
+  }
+
+  @Override
+  public TraceContextHandlerState replace(TraceContext newRoot) {
+    return getHandler().replace(newRoot);
+  }
+
+  @Override
+  public void restore(TraceContextHandlerState toRestore) {
+    getHandler().restore(toRestore);
+  }
+
   private DefaultTraceContextHandler getHandler() {
     DefaultTraceContextHandler handler = handlers.get();
     if (handler == null) {

--- a/sdk/core/src/main/java/com/google/cloud/trace/TraceContextHandler.java
+++ b/sdk/core/src/main/java/com/google/cloud/trace/TraceContextHandler.java
@@ -40,4 +40,48 @@ public interface TraceContextHandler {
    * @return the context on the top of the stack or null if the stack if empty.
    */
   TraceContext pop();
+
+  /**
+   * Makes the trace context on top of the stack the new root context.
+   * The stack cannot be popped below this context until restore(TraceContextHandlerState) is called.
+   * @return The {@link TraceContextHandlerState} for the stack prior to adding the top element.
+   */
+  TraceContextHandlerState replace();
+
+  /**
+   * Add a new root context to the top of the stack.
+   * The stack cannot be popped below this context until restore(TraceContextHandlerState) is called.
+   * @param newRoot The new root trace context to attach.
+   * @return The {@link TraceContextHandlerState} for the stack prior to adding the new root.
+   */
+  TraceContextHandlerState replace(TraceContext newRoot);
+
+  /**
+   * Restore the stack to the provided state.
+   * This will remove trace contexts that have been pushed (but not popped) since the call to replace()
+   * that returned the provided {@link TraceContextHandlerState}
+   * @param toRestore The {@link TraceContextHandlerState} returned by replace()
+   */
+  void restore(TraceContextHandlerState toRestore);
+
+  /**
+   * Represents the state of the stack in the TraceContextHandler
+   */
+  class TraceContextHandlerState {
+    private final int rootIndex;
+    private final int size;
+
+    public TraceContextHandlerState(int rootIndex, int size) {
+      this.rootIndex = rootIndex;
+      this.size = size;
+    }
+
+    public int getRootIndex() {
+      return rootIndex;
+    }
+
+    public int getSize() {
+      return size;
+    }
+  }
 }


### PR DESCRIPTION
Add replace() and restore() to TraceContextHandler. This should help instrumentation to have better control over resetting the state of the TraceContextHandler stack.
