### PR TITLE
Refactoring SpanContextHandler interface 

### DIFF
--- a/guice/annotation/src/main/java/com/google/cloud/trace/guice/annotation/TracerSpanInterceptor.java
+++ b/guice/annotation/src/main/java/com/google/cloud/trace/guice/annotation/TracerSpanInterceptor.java
@@ -94,7 +94,8 @@ public class TracerSpanInterceptor implements MethodInterceptor {
     Tracer tracer = tracerProvider.get();
     TraceContext traceContext = tracer.startSpan(methodName, new StartSpanOptions()
         .setEnableTrace(enableTrace).setEnableStackTrace(enableStackTrace));
-    boolean stackTraceEnabled = traceContext.getCurrent().getTraceOptions().getStackTraceEnabled();
+    boolean stackTraceEnabled = traceContext.getHandle().getCurrentSpanContext().getTraceOptions()
+        .getStackTraceEnabled();
 
     boolean labelAllParams = span.labelAll();
     String labelPrefix;

--- a/guice/servlet/src/main/java/com/google/cloud/trace/guice/servlet/RequestTraceContextFilter.java
+++ b/guice/servlet/src/main/java/com/google/cloud/trace/guice/servlet/RequestTraceContextFilter.java
@@ -17,8 +17,8 @@ package com.google.cloud.trace.guice.servlet;
 import com.google.cloud.trace.SpanContextHandler;
 import com.google.cloud.trace.core.SpanContext;
 import com.google.cloud.trace.core.SpanContextFactory;
+import com.google.cloud.trace.core.SpanContextHandle;
 import com.google.inject.Inject;
-import com.google.inject.Key;
 import com.google.inject.Singleton;
 import java.io.IOException;
 import javax.servlet.Filter;
@@ -59,11 +59,11 @@ public class RequestTraceContextFilter implements Filter {
     } else {
       context = spanContextFactory.initialContext();
     }
-    SpanContext previous = spanContextHandler.attach(context);
+    SpanContextHandle handle = spanContextHandler.attach(context);
     try {
       chain.doFilter(request, response);
     } finally {
-      spanContextHandler.detach(previous);
+      handle.detach();
     }
   }
 }

--- a/sdk/core-testing/src/main/java/com/google/cloud/trace/TestSpanContextHandler.java
+++ b/sdk/core-testing/src/main/java/com/google/cloud/trace/TestSpanContextHandler.java
@@ -15,6 +15,7 @@
 package com.google.cloud.trace;
 
 import com.google.cloud.trace.core.SpanContext;
+import com.google.cloud.trace.core.SpanContextHandle;
 import com.google.cloud.trace.core.SpanId;
 import com.google.cloud.trace.core.TraceId;
 import com.google.cloud.trace.core.TraceOptions;
@@ -42,14 +43,35 @@ public class TestSpanContextHandler implements SpanContextHandler {
   }
 
   @Override
-  public SpanContext attach(SpanContext context) {
+  public SpanContextHandle attach(SpanContext context) {
     SpanContext temp = currentContext;
     this.currentContext = context;
-    return temp;
+    return new TestSpanContextHandle(this, currentContext, temp);
   }
 
-  @Override
-  public void detach(SpanContext toAttach) {
+  private void detach(SpanContext toAttach) {
     this.currentContext = toAttach;
+  }
+
+  private static class TestSpanContextHandle implements SpanContextHandle {
+    private TestSpanContextHandler handler;
+    private SpanContext current, previous;
+
+    public TestSpanContextHandle(TestSpanContextHandler handler,
+        SpanContext current, SpanContext previous) {
+      this.handler = handler;
+      this.current = current;
+      this.previous = previous;
+    }
+
+    @Override
+    public SpanContext getCurrentSpanContext() {
+      return current;
+    }
+
+    @Override
+    public void detach() {
+      handler.detach(previous);
+    }
   }
 }

--- a/sdk/core-testing/src/test/java/com/google/cloud/trace/TestSpanContextHandlerTest.java
+++ b/sdk/core-testing/src/test/java/com/google/cloud/trace/TestSpanContextHandlerTest.java
@@ -48,15 +48,15 @@ public class TestSpanContextHandlerTest {
   @Test
   public void testAttach() {
     TestSpanContextHandler handler = new TestSpanContextHandler();
-    SpanContext previous = handler.attach(context);
+    handler.attach(context);
     assertThat(handler.current()).isEqualTo(context);
-    assertThat(previous).isEqualTo(TestSpanContextHandler.TEST_CONTEXT);
   }
 
   @Test
   public void testDetach() {
-    TestSpanContextHandler handler = new TestSpanContextHandler();
-    handler.detach(context);
-    assertThat(handler.current()).isEqualTo(context);
+    TestSpanContextHandler handler = new TestSpanContextHandler(
+        TestSpanContextHandler.TEST_CONTEXT);
+    handler.attach(context).detach();
+    assertThat(handler.current()).isEqualTo(TestSpanContextHandler.TEST_CONTEXT);
   }
 }

--- a/sdk/core/src/main/java/com/google/cloud/trace/SpanContextHandler.java
+++ b/sdk/core/src/main/java/com/google/cloud/trace/SpanContextHandler.java
@@ -15,6 +15,7 @@
 package com.google.cloud.trace;
 
 import com.google.cloud.trace.core.SpanContext;
+import com.google.cloud.trace.core.SpanContextHandle;
 
 /**
  * An interface for managing span contexts.
@@ -32,14 +33,8 @@ public interface SpanContextHandler {
 
   /**
    * Replace the current SpanContext with a new SpanContext.
-   * @param context the {@link SpanContext} to attach
-   * @return The previous SpanContext
+   * @param context the {@link SpanContext} to attach.
+   * @return a handle to the attached context.
    */
-  SpanContext attach(SpanContext context);
-
-  /**
-   * Replace the current SpanContext with a previous SpanContext.
-   * @param toAttach the previous SpanContext that should be re-attached.
-   */
-  void detach(SpanContext toAttach);
+  SpanContextHandle attach(SpanContext context);
 }

--- a/sdk/core/src/main/java/com/google/cloud/trace/core/SpanContextHandle.java
+++ b/sdk/core/src/main/java/com/google/cloud/trace/core/SpanContextHandle.java
@@ -15,16 +15,19 @@
 package com.google.cloud.trace.core;
 
 /**
- * Represents the current context of a Trace.
+ * A handle to a span context. This can be used to detach the span context from the current context.
  */
-public class TraceContext {
-  private final SpanContextHandle handle;
+public interface SpanContextHandle {
 
-  public TraceContext(SpanContextHandle handle) {
-    this.handle = handle;
-  }
+  /**
+   * Returns the current span context.
+   *
+   * @return the current span context.
+   */
+  SpanContext getCurrentSpanContext();
 
-  public SpanContextHandle getHandle() {
-    return handle;
-  }
+  /**
+   * Detaches the span context from the current context.
+   */
+  void detach();
 }

--- a/sdk/implementation/src/main/java/com/google/cloud/trace/DetachedSpanContextHandle.java
+++ b/sdk/implementation/src/main/java/com/google/cloud/trace/DetachedSpanContextHandle.java
@@ -12,19 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.cloud.trace.core;
+package com.google.cloud.trace;
+
+import com.google.cloud.trace.core.SpanContext;
+import com.google.cloud.trace.core.SpanContextHandle;
 
 /**
- * Represents the current context of a Trace.
+ * A SpanContextHandle that is not associated with the current context. Calling detach() will have
+ * no effect.
  */
-public class TraceContext {
-  private final SpanContextHandle handle;
+public class DetachedSpanContextHandle implements SpanContextHandle {
+  private final SpanContext spanContext;
 
-  public TraceContext(SpanContextHandle handle) {
-    this.handle = handle;
+  public DetachedSpanContextHandle(SpanContext spanContext) {
+    this.spanContext = spanContext;
   }
 
-  public SpanContextHandle getHandle() {
-    return handle;
+  @Override
+  public SpanContext getCurrentSpanContext() {
+    return spanContext;
   }
+
+  @Override
+  public void detach() {}
 }

--- a/sdk/implementation/src/test/java/com/google/cloud/trace/GrpcSpanContextHandlerTest.java
+++ b/sdk/implementation/src/test/java/com/google/cloud/trace/GrpcSpanContextHandlerTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.trace.core.SpanContext;
+import com.google.cloud.trace.core.SpanContextHandle;
 import com.google.cloud.trace.core.SpanId;
 import com.google.cloud.trace.core.TraceId;
 import com.google.cloud.trace.core.TraceOptions;
@@ -32,13 +33,13 @@ public class GrpcSpanContextHandlerTest {
   public void testAttachDetach() throws Exception {
     SpanContextHandler contextHandler = new GrpcSpanContextHandler(first);
     assertThat(contextHandler.current()).isEqualTo(first);
-    assertThat(contextHandler.attach(second)).isEqualTo(first);
+    SpanContextHandle handle1 = contextHandler.attach(second);
     assertThat(contextHandler.current()).isEqualTo(second);
-    assertThat(contextHandler.attach(third)).isEqualTo(second);
+    SpanContextHandle handle2 = contextHandler.attach(third);
     assertThat(contextHandler.current()).isEqualTo(third);
-    contextHandler.detach(second);
+    handle2.detach();
     assertThat(contextHandler.current()).isEqualTo(second);
-    contextHandler.detach(first);
+    handle1.detach();
     assertThat(contextHandler.current()).isEqualTo(first);
   }
 }

--- a/sdk/service/src/main/java/com/google/cloud/trace/Trace.java
+++ b/sdk/service/src/main/java/com/google/cloud/trace/Trace.java
@@ -17,6 +17,7 @@ package com.google.cloud.trace;
 import com.google.cloud.trace.core.EndSpanOptions;
 import com.google.cloud.trace.core.Labels;
 import com.google.cloud.trace.core.SpanContext;
+import com.google.cloud.trace.core.SpanContextHandle;
 import com.google.cloud.trace.core.SpanId;
 import com.google.cloud.trace.core.StackTrace;
 import com.google.cloud.trace.core.StartSpanOptions;
@@ -45,7 +46,7 @@ public class Trace {
       service = new TraceService() {
         private final SpanContext spanContext = new SpanContext(
             TraceId.invalid(), SpanId.invalid(), new TraceOptions());
-        private final TraceContext traceContext = new TraceContext(spanContext, null);
+        private final TraceContext traceContext = new TraceContext(new NoSpanContextHandle(spanContext));
         private final Tracer tracer = new NoTracer(traceContext);
         private final SpanContextHandler spanContextHandler = new NoSpanContextHandler(spanContext);
         @Override
@@ -103,10 +104,24 @@ public class Trace {
       return context;
     }
     @Override
-    public SpanContext attach(SpanContext context) {
+    public SpanContextHandle attach(SpanContext context) {
+      return new NoSpanContextHandle(context);
+    }
+  }
+
+  private static class NoSpanContextHandle implements SpanContextHandle {
+    private final SpanContext context;
+
+    private NoSpanContextHandle(SpanContext context) {
+      this.context = context;
+    }
+
+    @Override
+    public SpanContext getCurrentSpanContext() {
       return context;
     }
+
     @Override
-    public void detach(SpanContext toAttach) {}
+    public void detach() {}
   }
 }

--- a/sdk/service/src/test/java/com/google/cloud/trace/TraceTest.java
+++ b/sdk/service/src/test/java/com/google/cloud/trace/TraceTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.cloud.trace.core.EndSpanOptions;
 import com.google.cloud.trace.core.Labels;
 import com.google.cloud.trace.core.SpanContext;
+import com.google.cloud.trace.core.SpanContextHandle;
 import com.google.cloud.trace.core.StackTrace;
 import com.google.cloud.trace.core.StartSpanOptions;
 import com.google.cloud.trace.core.TraceContext;
@@ -29,13 +30,13 @@ public class TraceTest {
   public void testGetTracer_No() {
     Tracer tracer = Trace.getTracer();
     TraceContext context = tracer.startSpan("hello");
-    assertInvalid(context.getCurrent());
+    assertInvalid(context.getHandle().getCurrentSpanContext());
     tracer.annotateSpan(context, Labels.builder().build());
     tracer.setStackTrace(context, StackTrace.builder().build());
     tracer.endSpan(context);
 
     context = tracer.startSpan("hello", new StartSpanOptions());
-    assertInvalid(context.getCurrent());
+    assertInvalid(context.getHandle().getCurrentSpanContext());
     tracer.endSpan(context, new EndSpanOptions());
   }
 
@@ -43,10 +44,9 @@ public class TraceTest {
   public void testGetSpanContextHandler_No() {
     SpanContextHandler handler = Trace.getSpanContextHandler();
     assertInvalid(handler.current());
-    SpanContext attached = handler.attach(handler.current());
-    assertInvalid(attached);
+    SpanContextHandle handle = handler.attach(handler.current());
     assertInvalid(handler.current());
-    handler.detach(attached);
+    handle.detach();
     assertInvalid(handler.current());
   }
 

--- a/services/appengine-standard-service/src/main/java/com/google/cloud/trace/service/AppEngineSpanContextHandle.java
+++ b/services/appengine-standard-service/src/main/java/com/google/cloud/trace/service/AppEngineSpanContextHandle.java
@@ -17,8 +17,8 @@ package com.google.cloud.trace.service;
 import com.google.appengine.api.labs.trace.Span;
 import com.google.apphosting.api.CloudTraceContext;
 import com.google.cloud.trace.core.SpanContext;
+import com.google.cloud.trace.core.SpanContextHandle;
 import com.google.cloud.trace.core.SpanId;
-import com.google.cloud.trace.core.TraceContext;
 import com.google.cloud.trace.core.TraceId;
 import com.google.cloud.trace.core.TraceOptions;
 import com.google.common.base.Throwables;
@@ -28,30 +28,26 @@ import com.google.protos.cloud.trace.TraceId.TraceIdProto;
 import java.math.BigInteger;
 
 /**
- * Implementation of {@link TraceContext} based on Google App Engine's Trace
+ * Implementation of {@link SpanContextHandle} based on Google App Engine's Trace
  * Service API.
  */
-class AppEngineTraceContext extends TraceContext {
+class AppEngineSpanContextHandle implements SpanContextHandle {
   private final Span span;
 
-  AppEngineTraceContext(Span span) {
-    // TODO: TraceContext should be an interface.
-    super(null, null);
+  AppEngineSpanContextHandle(Span span) {
     this.span = span;
   }
 
-  Span getSpan() {
-    return span;
-  }
-
   @Override
-  public SpanContext getCurrent() {
+  public SpanContext getCurrentSpanContext() {
     return getSpanContext(span.getContext());
   }
 
   @Override
-  public SpanContext getParent() {
-    return getSpanContext(span.getParentContext());
+  public void detach() {}
+
+  Span getSpan() {
+    return span;
   }
 
   private static SpanContext getSpanContext(CloudTraceContext cloudTraceContext) {

--- a/services/appengine-standard-service/src/main/java/com/google/cloud/trace/service/AppEngineTracer.java
+++ b/services/appengine-standard-service/src/main/java/com/google/cloud/trace/service/AppEngineTracer.java
@@ -39,7 +39,7 @@ class AppEngineTracer implements Tracer {
   public TraceContext startSpan(String name) {
     checkNotNull(name);
 
-    return new AppEngineTraceContext(traceService.startSpan(name));
+    return new TraceContext(new AppEngineSpanContextHandle(traceService.startSpan(name)));
   }
 
   @Override
@@ -84,6 +84,6 @@ class AppEngineTracer implements Tracer {
   private Span getSpan(TraceContext traceContext) {
     checkNotNull(traceContext);
 
-    return ((AppEngineTraceContext) traceContext).getSpan();
+    return ((AppEngineSpanContextHandle) traceContext.getHandle()).getSpan();
   }
 }


### PR DESCRIPTION
Refactoring SpanContextHandler interface to allow implementations to have more flexible detach methods. The gRPC Context implementation is now able to correctly restore the previous value.