### PR TITLE
Fixed GrpcApiService initialization Error:

### DIFF
--- a/services/trace-grpc-api-service/src/main/java/com/google/cloud/trace/service/TraceGrpcApiService.java
+++ b/services/trace-grpc-api-service/src/main/java/com/google/cloud/trace/service/TraceGrpcApiService.java
@@ -133,8 +133,8 @@ public class TraceGrpcApiService implements TraceService {
       if(executorService == null) {
         ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1);
         // Have the flushing threads shutdown if idle for the scheduled delay.
-        scheduledThreadPoolExecutor.allowCoreThreadTimeOut(true);
         scheduledThreadPoolExecutor.setKeepAliveTime(scheduledDelay, TimeUnit.SECONDS);
+        scheduledThreadPoolExecutor.allowCoreThreadTimeOut(true);
         executorService = scheduledThreadPoolExecutor;
       }
 


### PR DESCRIPTION
allowCoreThreadTimeOut was called before setKeepAliveTime

Caused by: java.lang.IllegalArgumentException: Core threads must have nonzero keep alive times
        at java.util.concurrent.ThreadPoolExecutor.allowCoreThreadTimeOut(ThreadPoolExecutor.java:1642) ~[na:1.8.0_45]
        at com.google.cloud.trace.service.TraceGrpcApiService$Builder.build(TraceGrpcApiService.java:136) ~[trace-grpc-api-service-0.2.3.jar:na]