### PR TITLE
Update google-cloud-trace to 0.32.0-beta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.6.1</grpc.version>
-    <google-cloud-trace.version>0.24.0-alpha</google-cloud-trace.version>
+    <google-cloud-trace.version>0.32.0-beta</google-cloud-trace.version>
     <google-auth-library-credentials.version>0.8.0</google-auth-library-credentials.version>
     <google-auth-library-oauth2-http.version>0.8.0</google-auth-library-oauth2-http.version>
   </properties>

--- a/sinks/v1/grpc-consumer/src/main/java/com/google/cloud/trace/grpc/v1/GrpcTraceConsumer.java
+++ b/sinks/v1/grpc-consumer/src/main/java/com/google/cloud/trace/grpc/v1/GrpcTraceConsumer.java
@@ -69,13 +69,9 @@ public class GrpcTraceConsumer implements TraceConsumer {
     TraceServiceSettings traceServiceSettings =
         TraceServiceSettings.newBuilder()
             .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
-            .setTransportProvider(
-                TraceServiceSettings.defaultGrpcTransportProviderBuilder()
-                    .setChannelProvider(
-                        TraceServiceSettings.defaultGrpcChannelProviderBuilder()
-                            .setEndpoint(apiHost)
-                            .build())
-                    .build())
+            .setTransportChannelProvider(TraceServiceSettings.defaultGrpcTransportProviderBuilder()
+                .setEndpoint(apiHost)
+                .build())
             .build();
 
     return new GrpcTraceConsumer(TraceServiceClient.create(traceServiceSettings));


### PR DESCRIPTION
This allows cloud-trace-java to be used in conjunction
with newer GCP libraries that rely on newer versions of gax and
gax-grpc. 

This addresses #98 


