### PR TITLE
Update google-cloud-trace version and cleanup all poms.

### DIFF
--- a/guice/annotation/pom.xml
+++ b/guice/annotation/pom.xml
@@ -30,22 +30,22 @@
     <dependency>
       <groupId>aopalliance</groupId>
       <artifactId>aopalliance</artifactId>
-      <version>1.0</version>
+      <version>${aopalliance.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${google-guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-multibindings</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/guice/core/pom.xml
+++ b/guice/core/pom.xml
@@ -30,12 +30,12 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.1</version>
+      <version>${google-findbugs.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/guice/google-auth/pom.xml
+++ b/guice/google-auth/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>

--- a/guice/grpc-sink/pom.xml
+++ b/guice/grpc-sink/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/guice/java-timestamp/pom.xml
+++ b/guice/java-timestamp/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/guice/joda-timestamp/pom.xml
+++ b/guice/joda-timestamp/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/guice/servlet/pom.xml
+++ b/guice/servlet/pom.xml
@@ -35,22 +35,22 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-multibindings</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-servlet</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <version>${javax-servlet.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/guice/single-thread-scheduler/pom.xml
+++ b/guice/single-thread-scheduler/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/guice/v1/pom.xml
+++ b/guice/v1/pom.xml
@@ -35,12 +35,12 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-multibindings</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <!-- App Engine Trace API is available in 1.9.44+. -->
     <appengine-api.version>1.9.60</appengine-api.version>
     <google-guava.version>19.0</google-guava.version>
-    <google-protobuf.version>3.1.0</google-protobuf.version>
+    <google-protobuf.version>3.5.1</google-protobuf.version>
     <joda-time.version>2.9.4</joda-time.version>
     <google-inject-guice.version>4.0</google-inject-guice.version>
     <javax-servlet.version>2.5</javax-servlet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,21 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.9.0</grpc.version>
-    <google-cloud-trace.version>0.32.0-beta</google-cloud-trace.version>
+    <google-cloud-trace.version>0.34.0-beta</google-cloud-trace.version>
     <google-auth-library-credentials.version>0.9.0</google-auth-library-credentials.version>
     <google-auth-library-oauth2-http.version>0.9.0</google-auth-library-oauth2-http.version>
+    <!-- App Engine Trace API is available in 1.9.44+. -->
+    <appengine-api.version>1.9.60</appengine-api.version>
+    <google-guava.version>19.0</google-guava.version>
+    <google-protobuf.version>3.1.0</google-protobuf.version>
+    <joda-time.version>2.9.4</joda-time.version>
+    <google-inject-guice.version>4.0</google-inject-guice.version>
+    <javax-servlet.version>2.5</javax-servlet.version>
+    <aopalliance.version>1.0</aopalliance.version>
+    <!-- Test dependencies -->
+    <mockito.version>2.2.6</mockito.version>
+    <google-truth.version>0.30</google-truth.version>
+    <google-findbugs.version>3.0.1</google-findbugs.version>
   </properties>
 
   <modules>

--- a/samples/guice-scheduled-grpc/pom.xml
+++ b/samples/guice-scheduled-grpc/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${google-guava.version}</version>
     </dependency>
 
     <dependency>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
   </dependencies>
 

--- a/samples/guice-servlet-grpc/pom.xml
+++ b/samples/guice-servlet-grpc/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${google-guava.version}</version>
     </dependency>
 
     <dependency>
@@ -72,17 +72,17 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-servlet</artifactId>
-      <version>4.0</version>
+      <version>${google-inject-guice.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <version>${javax-servlet.version}</version>
     </dependency>
   </dependencies>
 

--- a/sdk/core-testing/pom.xml
+++ b/sdk/core-testing/pom.xml
@@ -25,13 +25,13 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.29</version>
+      <version>${google-truth.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.2.6</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sdk/core/pom.xml
+++ b/sdk/core/pom.xml
@@ -20,24 +20,24 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${google-guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.1</version>
+      <version>${google-findbugs.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.29</version>
+      <version>${google-truth.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.2.6</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sdk/implementation/pom.xml
+++ b/sdk/implementation/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${google-guava.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>3.0.1</version>
+      <version>${google-findbugs.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.29</version>
+      <version>${google-truth.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sdk/java-timestamp/pom.xml
+++ b/sdk/java-timestamp/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${google-guava.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/sdk/joda-timestamp/pom.xml
+++ b/sdk/joda-timestamp/pom.xml
@@ -25,12 +25,12 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${google-guava.version}</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.9.4</version>
+      <version>${joda-time.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/sdk/service/pom.xml
+++ b/sdk/service/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.29</version>
+      <version>${google-truth.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sdk/servlet/pom.xml
+++ b/sdk/servlet/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <version>${javax-servlet.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/services/appengine-standard-service/pom.xml
+++ b/services/appengine-standard-service/pom.xml
@@ -96,7 +96,7 @@
               <goal>test-compile</goal>
             </goals>
             <configuration>
-              <protocArtifact>com.google.protobuf:protoc:3.1.0:exe:${os.detected.classifier}</protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:${google-protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
             </configuration>
           </execution>
         </executions>

--- a/services/appengine-standard-service/pom.xml
+++ b/services/appengine-standard-service/pom.xml
@@ -13,9 +13,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <!-- App Engine Trace API is available in 1.9.44+. -->
-    <appengine.target.version>1.9.44</appengine.target.version>
   </properties>
 
   <dependencies>
@@ -23,7 +20,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>core</artifactId>
-      <version>0.7.0-SNAPSHOT</version>
+      <version>${project.version}</version>
       <type>jar</type>
     </dependency>
     <dependency>
@@ -49,7 +46,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>${appengine.target.version}</version>
+      <version>${appengine-api.version}</version>
       <!-- Intentionally marked as optional. We want the dependent project -->
       <!-- to specify the concrete version to use in a deployment. -->
       <optional>true</optional>
@@ -57,7 +54,7 @@
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-labs</artifactId>
-      <version>${appengine.target.version}</version>
+      <version>${appengine-api.version}</version>
       <!-- Intentionally marked as optional. We want the dependent project -->
       <!-- to specify the concrete version to use in a deployment. -->
       <optional>true</optional>
@@ -67,13 +64,13 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.30</version>
+      <version>${google-truth.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.2.9</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/services/appengine-standard-service/src/main/proto/cloud/trace/proto/trace_id.proto
+++ b/services/appengine-standard-service/src/main/proto/cloud/trace/proto/trace_id.proto
@@ -15,6 +15,7 @@
 syntax = "proto3";
 
 option java_package = "com.google.protos.cloud.trace";
+option optimize_for = LITE_RUNTIME;
 
 message TraceIdProto {
   fixed64 hi = 1;

--- a/services/appengine-standard-service/src/main/proto/cloud/trace/proto/trace_id.proto
+++ b/services/appengine-standard-service/src/main/proto/cloud/trace/proto/trace_id.proto
@@ -15,7 +15,6 @@
 syntax = "proto3";
 
 option java_package = "com.google.protos.cloud.trace";
-option optimize_for = LITE_RUNTIME;
 
 message TraceIdProto {
   fixed64 hi = 1;

--- a/sinks/v1/http-consumer/pom.xml
+++ b/sinks/v1/http-consumer/pom.xml
@@ -34,17 +34,17 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${google-guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.1.0</version>
+      <version>${google-protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>3.1.0</version>
+      <version>${google-protobuf.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/sinks/v1/sink/pom.xml
+++ b/sinks/v1/sink/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${google-guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -35,18 +35,18 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.1.0</version>
+      <version>${google-protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.29</version>
+      <version>${google-truth.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.2.6</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
When updated the protobuf the new version 3.5.1 does throws an exception when optimize_for = LITE_RUNTIME is used. Removed this for the moment.